### PR TITLE
added unique ids to major sections of the management page …

### DIFF
--- a/app/views/admin/roles/_role.html.haml
+++ b/app/views/admin/roles/_role.html.haml
@@ -12,7 +12,7 @@
   .panel.panel-primary
     .panel-heading
       = t(:role_info, scope: t_scope)
-      = link_to t(:role_export, scope: t_scope), role_export_admin_role_path(role), class: "btn btn-xs btn-warning pull-right"
+      = link_to t(:role_export, scope: t_scope), role_export_admin_role_path(role), class: "btn btn-xs btn-warning pull-right", id: "btn_role_export"
     .panel-body
       = form_for(role, url: change_admin_role_path(role), html: { class: "form-inline" } ) do |f|
         .row

--- a/app/views/layouts/the_role_management_panel.html.haml
+++ b/app/views/layouts/the_role_management_panel.html.haml
@@ -1,36 +1,36 @@
 !!!
 %html
   %head
-    %title TheRole
+    %title= request.domain
     = stylesheet_link_tag    :the_role_management_panel
     = javascript_include_tag :the_role_management_panel
     = stylesheet_link_tag "http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css"
 
     = csrf_meta_tags
   %body
-    .container
+    .container#role_container
       .row
-        .col-md-12.header
-          %p{ style: "text-align:center" }
+        .col-md-12.header#role_header
+          %p#role_title{ style: "text-align:center" }
             Authorization gem for Ruby on Rails with Management Panel
 
-          %p{ style: "text-align:center" }
+          %p#role_image{ style: "text-align:center" }
             = link_to "https://github.com/the-teacher/the_role" do
               = image_tag "https://raw.githubusercontent.com/TheRole/docs/master/images/the_role.png", alt: 'TheRole 3.0', width: 150
 
-          %p{ style: "text-align:center" }
+          %p#role_description{ style: "text-align:center" }
             Semantic. Flexible. Lightweight.
       .row
-        .col-md-3.manage_panel
+        .col-md-3.manage_panel#role_panel
           = yield :role_sidebar
-        .col-md-9.main_content
+        .col-md-9.main_content#role_content
           = render partial: 'the_notification/flash', locals: { format: :json }
           = yield
           = yield :role_main
 
       .row
         .col-md-12.center
-          %p{ style: "text-align:center" }
+          %p#roll_locales{ style: "text-align:center" }
             = link_to 'en', '/?locale=en'
             \|
             = link_to 'ru', '/?locale=ru'


### PR DESCRIPTION
...and set page title to grab the value of request.domain

I added div IDs to the HAML of the main containers so that it is easier to control the style of the page. I also set the title in the header to `request.domain` so that when you go to the page it shows the domain name of your Rails app. Simple changes, I've tested it using the dummy app and see no changes until I call those ID's directly in the stylesheet. Shouldn't break anything. 

NOTE: The version of the_role_management_panel on rubygems.com is NOT up to date. Can you push this version there once changes are merged?