### PR TITLE
Fix the verb tense for 'enable' button

### DIFF
--- a/app/views/admin/roles/_role.slim
+++ b/app/views/admin/roles/_role.slim
@@ -69,7 +69,7 @@
                   .col-md-3
                     .controls
                       - klass = value ? :success : :info
-                      - state = value ? t(:enable, scope: t_scope) : t(:disable, scope: t_scope)
+                      - state = value ? t(:enabled, scope: t_scope) : t(:disabled, scope: t_scope)
                       .btn-group
                         button(class="btn btn-#{klass}") = state
                         button(class="btn btn-#{klass} dropdown-toggle", data={toggle: :dropdown})

--- a/config/locales/en.the_role.gui.yml
+++ b/config/locales/en.the_role.gui.yml
@@ -7,8 +7,8 @@ en:
     section_not_created:      Section not created
     section_rule_created:     "Section rule created"
     section_rule_not_created: "Section rule not created"
-    section_rule_on:          "Section rule is enable"
-    section_rule_off:         "Section rule is disable"
+    section_rule_on:          "Section rule is enabled"
+    section_rule_off:         "Section rule is disabled"
     state_not_changed:        "Section rule not changed"
     section_deleted:          Section deleted
     section_not_deleted:      Section not deleted
@@ -32,6 +32,8 @@ en:
         rule_delete_confirm: 'Do you want to delete rule?'
         enable: Enable
         disable: Disable
+        enabled: Enabled
+        disabled: Disabled
         delete_rule: Delete rule
         new_section_placeholder: New section name
         create_section: Create new section

--- a/config/locales/es.the_role.gui.yml
+++ b/config/locales/es.the_role.gui.yml
@@ -31,6 +31,8 @@ es:
         rule_delete_confirm: "¿Quieres eliminar la regla?"
         enable: Activar
         disable: Desactivar
+        enabled: Activada
+        disabled: Desactivada
         delete_rule: Eliminar regla
         new_section_placeholder: Nombre de la nueva sección
         create_section: Crear nueva sección

--- a/config/locales/nl.the_role.gui.yml
+++ b/config/locales/nl.the_role.gui.yml
@@ -32,6 +32,8 @@ nl:
         rule_delete_confirm: 'Wil je het toegangsprofiel verwijderen?'
         enable: Activeren
         disable: Deactiveren
+        enabled: Activeren
+        disabled: Deactiveren
         delete_rule: Verwijder toegangsprofiel
         new_section_placeholder: Naam nieuwe sectie
         create_section: Maak nieuwe sectie aan

--- a/config/locales/nl.the_role.gui.yml
+++ b/config/locales/nl.the_role.gui.yml
@@ -32,8 +32,8 @@ nl:
         rule_delete_confirm: 'Wil je het toegangsprofiel verwijderen?'
         enable: Activeren
         disable: Deactiveren
-        enabled: Activeren
-        disabled: Deactiveren
+        enabled: Geactiveerd
+        disabled: Gedeactiveerd
         delete_rule: Verwijder toegangsprofiel
         new_section_placeholder: Naam nieuwe sectie
         create_section: Maak nieuwe sectie aan

--- a/config/locales/pl.the_role.gui.yml
+++ b/config/locales/pl.the_role.gui.yml
@@ -31,6 +31,8 @@ pl:
         rule_delete_confirm: 'Czy aby na pewno chcesz usunąć rolę?'
         enable: Włącz
         disable: Wyłącz
+        enabled: Włącz
+        disabled: Wyłącz
         delete_rule: Skasuj regułę
         new_section_placeholder: Nazwa nowej sekcji
         create_section: Utwórz nową sekcję

--- a/config/locales/pt_BR.the_role.gui.yml
+++ b/config/locales/pt_BR.the_role.gui.yml
@@ -32,6 +32,8 @@ pt-BR:
         rule_delete_confirm: 'Deseja excluir a regra?'
         enable: Habilitar
         disable: Desabilitar
+        enabled: Habilitada
+        disabled: Desabilitada
         delete_rule: Excluir regra
         new_section_placeholder: Nome da nova seção
         create_section: Criar nova seção

--- a/config/locales/ru.the_role.gui.yml
+++ b/config/locales/ru.the_role.gui.yml
@@ -33,6 +33,8 @@ ru:
         rule_delete_confirm: 'Вы хотите удалить правило?'
         enable: Включено
         disable: Отключено
+        enabled: Включено
+        disabled: Отключено
         delete_rule: Удалить правило
         new_section_placeholder: Имя нового раздела
         create_section: Создать раздел

--- a/config/locales/zh_CN.the_role.gui.yml
+++ b/config/locales/zh_CN.the_role.gui.yml
@@ -31,6 +31,8 @@ zh_CN:
         rule_delete_confirm: '你想删除规则?'
         enable: 可用
         disable: 不可用
+        enabled: 可用
+        disabled: 不可用
         delete_rule: 删除规则
         new_section_placeholder: 新章节名称
         create_section: 创建新章节


### PR DESCRIPTION
- This is just a small change to improve the usability

- Change the name on button to appear as 'enabled' (or 'disabled')

- The dropdown options remain the same

- Update the translations of PT_BR, ES and NL locales accordingly 